### PR TITLE
Mobile Menu Styling Update

### DIFF
--- a/frontend/src/Components/NavBar/MobileNavBar.css
+++ b/frontend/src/Components/NavBar/MobileNavBar.css
@@ -34,11 +34,25 @@
   color: white;
   font-size: 6vw;
   margin-bottom: 1em;
+  text-decoration: none;
 }
 
 .menu-item:active {
   color: var(--red);
 }
+
+.menu-item:link {
+  color: white !important;
+}
+
+.menu-item:visited {
+  color: white !important;
+}
+
+.menu-item:hover {
+  color: var(--red) !important;
+}
+
 
 #faq {
   margin-bottom: 1em !important;


### PR DESCRIPTION
# The Problem
First of all, the underlining on the mobile menu looked a bit odd so that needed to be removed. Mainly, there is built in linking where once you click a link, the text turns blue. Even though we changed that to red, it was still sometimes turning blue. 

# Changes
- Removed the underline
- Added overrides to the linking colors to ensure clicking won't turn blue