### PR TITLE
Updated Button Size on Schedule Page

### DIFF
--- a/frontend/src/Pages/SchedulePage/SchedulePage.jsx
+++ b/frontend/src/Pages/SchedulePage/SchedulePage.jsx
@@ -9,7 +9,7 @@ const SchedulePage = () => {
       <h1>Schedule</h1>
       <Nav.Link
         className="button btn btn-outline"
-				style={{padding:'5px'}}
+				style={{padding:'7px'}}
         href="https://calendar.google.com/calendar/u/0?cid=MDNmMmY5MDlhNjNkOTU1ZjljODIyOGQyNzM3NzJkOTg4NzA4NDM5YzBkOTc4ZDgwNTA2MWJhZWMyNTlkOTgxZUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t"
       >
         Add To Google Calendar!


### PR DESCRIPTION
![image](https://github.com/hack-rpi/HackRPI-Website2023/assets/143554630/31c4e421-b307-4712-9785-d26f11234da8)

The "Add To Calendar" button on the Schedule page was reported to be too small. I've changed the padding so it goes up from 5 to 7.


